### PR TITLE
Remove defer from jQuery and DataTables to fix pagination

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -251,13 +251,13 @@
     {% endfor %}
   {% endif %}
 
-  <script src="{{ "/static/js/jquery.min.js" | prepend: site.baseurl }}" defer></script>
+  <script src="{{ "/static/js/jquery.min.js" | prepend: site.baseurl }}"></script>
   <script src="{{ "/static/js/jquery.qtip.min.js" | prepend: site.baseurl }}" defer></script>
   <script src="{{ "/static/js/jquery.tweet.js" | prepend: site.baseurl }}" defer></script>
   <script src="{{ "/static/js/jquery.flexslider-min.js" | prepend: site.baseurl }}" defer></script>
   <script src="https://cdn.datatables.net/1.10.6/js/jquery.dataTables.min.js"
           integrity="sha384-ShqaqoNf8jU7jX5t0rRB92xkhkJ2JmaO+w0CRy8038lVvRk/dkV/V0YlJ6ApAFnX"
-          crossorigin="anonymous" defer></script>
+          crossorigin="anonymous"></script>
   <script src="{{ "/static/js/jquery.parallax-1.1.3.js" | prepend: site.baseurl }}" defer></script>
   <script src="{{ "/static/js/jquery.easing.1.3.js" | prepend: site.baseurl }}" defer></script>
   <script src="{{ "/static/js/jquery.easy-pie-chart.js" | prepend: site.baseurl }}" defer></script>


### PR DESCRIPTION
The defer attribute caused a race condition where the inline DataTables initialization script ran before jQuery and DataTables were loaded, breaking the pagination functionality.