### PR TITLE
Add modal for checkout instead of opening new tab

### DIFF
--- a/store.html
+++ b/store.html
@@ -2,6 +2,71 @@
 layout: default
 ---
 
+<!-- Checkout Modal -->
+<div id="checkout-modal" class="checkout-modal" style="display: none;">
+    <div class="checkout-modal-backdrop"></div>
+    <div class="checkout-modal-content">
+        <button class="checkout-modal-close" aria-label="Close">&times;</button>
+        <iframe id="checkout-iframe" src="" frameborder="0"></iframe>
+    </div>
+</div>
+
+<style>
+    .checkout-modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .checkout-modal-backdrop {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.7);
+    }
+    .checkout-modal-content {
+        position: relative;
+        width: 80%;
+        height: 80%;
+        max-height: 700px;
+        background: #fff;
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    }
+    .checkout-modal-close {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        width: 36px;
+        height: 36px;
+        border: none;
+        background: rgba(0, 0, 0, 0.1);
+        border-radius: 50%;
+        font-size: 24px;
+        line-height: 1;
+        cursor: pointer;
+        z-index: 10;
+        color: #333;
+        transition: background 0.2s;
+    }
+    .checkout-modal-close:hover {
+        background: rgba(0, 0, 0, 0.2);
+    }
+    #checkout-iframe {
+        width: 100%;
+        height: 100%;
+        border: none;
+    }
+</style>
+
 <section id="Store" class="parallax">
     <div class="container">
         <div class="row-fluid">
@@ -46,6 +111,23 @@ layout: default
 </section>
 
 <script>
+    // Modal functions
+    function openCheckoutModal(url) {
+        const modal = document.getElementById('checkout-modal');
+        const iframe = document.getElementById('checkout-iframe');
+        iframe.src = url;
+        modal.style.display = 'flex';
+        document.body.style.overflow = 'hidden';
+    }
+
+    function closeCheckoutModal() {
+        const modal = document.getElementById('checkout-modal');
+        const iframe = document.getElementById('checkout-iframe');
+        modal.style.display = 'none';
+        iframe.src = '';
+        document.body.style.overflow = '';
+    }
+
     // Check for success parameter in URL
     function checkForSuccess() {
         const params = new URLSearchParams(window.location.search);
@@ -73,7 +155,7 @@ layout: default
                     <p style="font-size: 18px; line-height: 20px; font-weight: 600;">${name}</p>
                     ${description ? `<p style="font-size: 14px; line-height: 18px; color: #666; margin: 10px 0;">${description}</p>` : ''}
                     ${price ? `<p style="font-size: 18px; line-height: 20px; font-weight: 600; margin-bottom: 15px;">${price}</p>` : ''}
-                    <a target="_blank" href="${url}" style="display: inline-block; font-size: 18px; line-height: 48px; height: 48px; color: #ffffff; min-width: 212px; background-color: #006aff; text-align: center; box-shadow: 0 0 0 1px rgba(0,0,0,.1) inset; border-radius: 6px; text-decoration: none;">${type === 'Service' ? 'Book Now' : 'Buy Now'}</a>
+                    <a href="${url}" onclick="openCheckoutModal('${url}'); return false;" style="display: inline-block; font-size: 18px; line-height: 48px; height: 48px; color: #ffffff; min-width: 212px; background-color: #006aff; text-align: center; box-shadow: 0 0 0 1px rgba(0,0,0,.1) inset; border-radius: 6px; text-decoration: none; cursor: pointer;">${type === 'Service' ? 'Book Now' : 'Buy Now'}</a>
                 </div>
             </div>
         `;
@@ -125,5 +207,14 @@ layout: default
     document.addEventListener('DOMContentLoaded', function() {
         checkForSuccess();
         loadInventory();
+
+        // Modal close handlers
+        document.querySelector('.checkout-modal-close').addEventListener('click', closeCheckoutModal);
+        document.querySelector('.checkout-modal-backdrop').addEventListener('click', closeCheckoutModal);
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') {
+                closeCheckoutModal();
+            }
+        });
     });
 </script>


### PR DESCRIPTION
Buy Now and Book Now buttons now open a modal with an iframe displaying the checkout page, rather than opening a new browser tab. Modal includes close button, backdrop click, and Escape key to close.