### PR TITLE
Move store password to GitHub Secrets with graceful fallback

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Build TypeScript bundles
         run: npm run build
+        env:
+          STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ This site uses Jekyll for static site generation and TypeScript for client-side 
 
 3. **Build TypeScript**:
    ```bash
+   # Set store password (optional - if not set, store will have open access)
+   export STORE_PASSWORD="your_password_here"
+
    # Production build
    npm run build
 
@@ -132,6 +135,11 @@ This site uses Jekyll for static site generation and TypeScript for client-side 
    # Watch mode for development
    npm run watch
    ```
+
+   **Notes**:
+   - The `STORE_PASSWORD` environment variable is hashed at build time and injected into the bundle
+   - If `STORE_PASSWORD` is not set, the build will succeed with a warning and the store will be accessible without password protection (useful for local development)
+   - Never commit the plain password to the repository
 
 4. **Run Jekyll development server**:
    ```bash
@@ -253,6 +261,23 @@ python _scripts/enrich_inventory.py static/files/store/inventory.json
 
 ## Configuration
 
+### GitHub Secrets
+
+The following secrets should be configured in your GitHub repository for production deployment:
+
+**Optional Secrets:**
+- `STORE_PASSWORD`: The plain-text password for the photography store. This is hashed at build time and injected into the password-verification bundle.
+
+**How to add secrets:**
+1. Go to your repository on GitHub
+2. Navigate to Settings → Secrets and variables → Actions
+3. Click "New repository secret"
+4. Add `STORE_PASSWORD` with your chosen password value
+
+The secret is automatically used in the GitHub Actions workflow during the TypeScript build step.
+
+**⚠️ Important**: If `STORE_PASSWORD` is not set, the build will succeed with a warning, but the store will be accessible **without password protection**. This is useful for local development but should be avoided in production.
+
 ### Jekyll Configuration ([_config.yml](_config.yml))
 
 - Site metadata (title, description, author)
@@ -295,11 +320,14 @@ python _scripts/enrich_inventory.py static/files/store/inventory.json
 
 ## Security Features
 
-- Password-protected store with SHA-256 hashing
-- XSS prevention via HTML escaping
-- Square Checkout iframe sandboxing
-- SessionStorage (not localStorage) for temporary access
-- Input validation and sanitization
+- **Password-protected store** with SHA-256 hashing
+  - Plain password stored in GitHub Secrets (never committed to repository)
+  - Hashed at build time and injected into bundle via webpack DefinePlugin
+  - Zero plain-text passwords in source code or version control
+- **XSS prevention** via HTML escaping
+- **Square Checkout iframe sandboxing** with CSP-style domain whitelisting
+- **SessionStorage** (not localStorage) for temporary access tokens
+- **Input validation and sanitization** throughout forms
 
 ## Performance Optimizations
 
@@ -327,7 +355,21 @@ npm run build
 The workflow continues on error if Semantic Scholar API is unavailable. Check logs in GitHub Actions for warnings.
 
 ### Store Password Issues
-Password is hashed with SHA-256. Update the expected hash in [password-verification.ts](_typescript/src/password-verification.ts) if changing the password.
+
+The store password is managed securely through environment variables:
+
+1. **For GitHub Actions**: Set the `STORE_PASSWORD` secret in your repository settings (Settings → Secrets and variables → Actions → New repository secret)
+2. **For local development**: Set `export STORE_PASSWORD="your_password"` before building TypeScript
+3. The password is SHA-256 hashed at build time by [generate-password-hash.js](_typescript/generate-password-hash.js)
+4. The hash is injected into the bundle via webpack's DefinePlugin (see [webpack.config.js](_typescript/webpack.config.js))
+
+**Never commit the plain password or hash to the repository.** The password is injected at build time from the environment.
+
+**Missing Password Behavior:**
+- If `STORE_PASSWORD` is not set during build, you'll see a warning: `⚠️ WARNING: STORE_PASSWORD environment variable is not set`
+- The build will succeed, but the store will be in **OPEN ACCESS mode** (no password protection)
+- The browser console will show: `Store is running in OPEN ACCESS mode (no password protection)`
+- This is useful for local development but should be avoided in production deployments
 
 ## License
 

--- a/_typescript/generate-password-hash.js
+++ b/_typescript/generate-password-hash.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * Generates a SHA-256 hash from the STORE_PASSWORD environment variable.
+ * This hash is injected into the webpack build at compile time.
+ *
+ * Usage:
+ *   STORE_PASSWORD="mypassword" node generate-password-hash.js
+ *
+ * Returns the hash as a JSON string for use in webpack DefinePlugin.
+ */
+
+const crypto = require('crypto');
+
+function generatePasswordHash() {
+  const password = process.env.STORE_PASSWORD;
+
+  if (!password) {
+    console.warn('');
+    console.warn('⚠️  WARNING: STORE_PASSWORD environment variable is not set');
+    console.warn('⚠️  Store will be accessible WITHOUT password protection');
+    console.warn('⚠️  Set STORE_PASSWORD in GitHub Secrets or local environment for production');
+    console.warn('');
+    return null;
+  }
+
+  // Generate SHA-256 hash
+  const hash = crypto
+    .createHash('sha256')
+    .update(password)
+    .digest('hex');
+
+  return hash;
+}
+
+// Generate hash and output as JSON string for webpack
+const hash = generatePasswordHash();
+console.log(JSON.stringify(hash));

--- a/_typescript/src/password-verification.ts
+++ b/_typescript/src/password-verification.ts
@@ -1,5 +1,14 @@
 // Password protection (SHA-256 hash)
-const STORE_PASSWORD_HASH = '83006a438f94daf3a7dd9c7b27f70c15e443c0ca55d58fcdfa76899ae466b455';
+// This hash is injected at build time from the STORE_PASSWORD environment variable
+// via webpack DefinePlugin. See webpack.config.js and generate-password-hash.js
+// If null, the password gate is automatically bypassed (open access mode)
+declare const process: {
+  env: {
+    STORE_PASSWORD_HASH: string | null;
+  };
+};
+
+const STORE_PASSWORD_HASH = process.env.STORE_PASSWORD_HASH;
 
 // HTML escaping to prevent XSS
 function escapeHtml(str: string | null | undefined): string {
@@ -100,7 +109,18 @@ function checkAccess(): void {
   const gate = document.getElementById('password-gate');
   const store = document.getElementById('store-main');
 
-  if (sessionStorage.getItem('store_access') === 'granted' && gate && store) {
+  if (!gate || !store) return;
+
+  // If no password is set at build time, grant immediate access (open mode)
+  if (STORE_PASSWORD_HASH === null) {
+    console.warn('Store is running in OPEN ACCESS mode (no password protection)');
+    gate.style.display = 'none';
+    store.style.display = 'block';
+    return;
+  }
+
+  // Check if user has already been granted access in this session
+  if (sessionStorage.getItem('store_access') === 'granted') {
     gate.style.display = 'none';
     store.style.display = 'block';
   }

--- a/_typescript/webpack.config.js
+++ b/_typescript/webpack.config.js
@@ -1,4 +1,21 @@
 const path = require('path');
+const { execSync } = require('child_process');
+const webpack = require('webpack');
+
+// Generate password hash from environment variable at build time
+// Returns null if no password is set (allows open access to store)
+function getPasswordHash() {
+  try {
+    const output = execSync('node _typescript/generate-password-hash.js', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'inherit'], // Only capture stdout, show stderr (warnings)
+    }).trim();
+    return JSON.parse(output); // Returns hash string or null
+  } catch (error) {
+    console.error('Failed to generate password hash');
+    throw error;
+  }
+}
 
 module.exports = {
   mode: 'production',
@@ -6,6 +23,11 @@ module.exports = {
     main: './_typescript/src/main.ts',
     'password-verification': './_typescript/src/password-verification.ts'
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.STORE_PASSWORD_HASH': JSON.stringify(getPasswordHash()),
+    }),
+  ],
   module: {
     rules: [
       {


### PR DESCRIPTION
Implements secure password management using environment variables:
- Store password now read from STORE_PASSWORD environment variable
- Hashed at build time via generate-password-hash.js Node.js script
- Injected into webpack bundle using DefinePlugin
- No passwords or hashes committed to repository

Features:
- GitHub Actions workflow updated to use secrets.STORE_PASSWORD
- Graceful fallback: builds succeed without password (open access mode)
- Clear warnings at build time and runtime when password not set
- Updated README with comprehensive setup and troubleshooting docs

Security improvements:
- Zero plain-text passwords in source code or version control
- Password hash generated dynamically at build time
- Session-scoped protection with open mode for development