### PR TITLE
Add Base64 obfuscation for store content

### DIFF
--- a/_typescript/encode-store-content.js
+++ b/_typescript/encode-store-content.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+/**
+ * Encodes store HTML content to Base64 for obfuscation.
+ * This prevents casual viewing of store content in page source.
+ *
+ * Note: This is security through obscurity, not true security.
+ * The real security is the password protection. This just makes it
+ * harder to casually view the content without entering the password.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// The HTML content to encode (store section)
+const storeContent = `<section id="Store" class="parallax">
+    <div class="container">
+        <div class="row-fluid">
+            <div class="store-content span12">
+                <div class="store-intro">
+                    <p>Purchase prints or book a portrait session.</p>
+                </div>
+
+                <!-- Success Message -->
+                <div id="success-message" class="success-banner" role="status" aria-live="polite" style="display: none;">
+                    <p>Thank you for your purchase! You'll receive a confirmation email shortly.</p>
+                </div>
+
+                <div class="store-sections">
+                    <!-- Prints Section -->
+                    <div class="store-section">
+                        <h3>Prints</h3>
+                        <p class="section-description">High-quality prints of my photography, professionally printed on archival paper.</p>
+
+                        <div class="product-grid" id="prints-grid">
+                            <div class="loading-placeholder">Loading prints...</div>
+                        </div>
+                    </div>
+
+                    <!-- Services Section -->
+                    <div class="store-section">
+                        <h3>Photography Services</h3>
+                        <p class="section-description">Book a portrait session for professional headshots, family photos, or special occasions.</p>
+
+                        <div class="services-grid" id="services-grid">
+                            <div class="loading-placeholder">Loading services...</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="store-outro">
+                    <p><a href="/#Photography" class="back-link">&larr; Back</a></p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>`;
+
+// Encode to Base64
+const encoded = Buffer.from(storeContent).toString('base64');
+
+// Output as JSON string for webpack
+console.log(JSON.stringify(encoded));

--- a/_typescript/src/password-verification.ts
+++ b/_typescript/src/password-verification.ts
@@ -2,13 +2,17 @@
 // This hash is injected at build time from the STORE_PASSWORD environment variable
 // via webpack DefinePlugin. See webpack.config.js and generate-password-hash.js
 // If null, the password gate is automatically bypassed (open access mode)
+//
+// Store content is Base64 encoded and injected at build time for obfuscation
 declare const process: {
   env: {
     STORE_PASSWORD_HASH: string | null;
+    STORE_CONTENT_ENCODED: string;
   };
 };
 
 const STORE_PASSWORD_HASH = process.env.STORE_PASSWORD_HASH;
+const STORE_CONTENT_ENCODED = process.env.STORE_CONTENT_ENCODED;
 
 // HTML escaping to prevent XSS
 function escapeHtml(str: string | null | undefined): string {
@@ -26,6 +30,26 @@ async function hashPassword(password: string): Promise<string> {
   return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
+// Decode and inject store content from Base64
+function injectStoreContent(): void {
+  const store = document.getElementById('store-main');
+  if (!store) return;
+
+  try {
+    // Decode Base64 content
+    const decoded = atob(STORE_CONTENT_ENCODED);
+    store.innerHTML = decoded;
+
+    // Initialize store functionality after content is injected
+    // Trigger custom event that store.html script can listen for
+    const event = new CustomEvent('storeContentLoaded');
+    document.dispatchEvent(event);
+  } catch (error) {
+    console.error('Failed to load store content:', error);
+    store.innerHTML = '<div style="padding: 2rem; text-align: center;">Failed to load store content. Please refresh the page.</div>';
+  }
+}
+
 // Animate transition from password gate to store
 function unlockStore(): void {
   const gate = document.getElementById('password-gate');
@@ -34,6 +58,9 @@ function unlockStore(): void {
   const gateBack = gate?.querySelector<HTMLElement>('.password-gate-back');
 
   if (!gate || !store) return;
+
+  // Inject store content before showing
+  injectStoreContent();
 
   // Show welcome message
   if (gateContent) {
@@ -114,6 +141,7 @@ function checkAccess(): void {
   // If no password is set at build time, grant immediate access (open mode)
   if (STORE_PASSWORD_HASH === null) {
     console.warn('Store is running in OPEN ACCESS mode (no password protection)');
+    injectStoreContent();
     gate.style.display = 'none';
     store.style.display = 'block';
     return;
@@ -121,6 +149,7 @@ function checkAccess(): void {
 
   // Check if user has already been granted access in this session
   if (sessionStorage.getItem('store_access') === 'granted') {
+    injectStoreContent();
     gate.style.display = 'none';
     store.style.display = 'block';
   }

--- a/_typescript/webpack.config.js
+++ b/_typescript/webpack.config.js
@@ -17,6 +17,20 @@ function getPasswordHash() {
   }
 }
 
+// Encode store content to Base64 for obfuscation at build time
+function getEncodedStoreContent() {
+  try {
+    const output = execSync('node _typescript/encode-store-content.js', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'inherit'],
+    }).trim();
+    return JSON.parse(output); // Returns Base64 encoded string
+  } catch (error) {
+    console.error('Failed to encode store content');
+    throw error;
+  }
+}
+
 module.exports = {
   mode: 'production',
   entry: {
@@ -26,6 +40,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.STORE_PASSWORD_HASH': JSON.stringify(getPasswordHash()),
+      'process.env.STORE_CONTENT_ENCODED': JSON.stringify(getEncodedStoreContent()),
     }),
   ],
   module: {

--- a/store.html
+++ b/store.html
@@ -35,49 +35,10 @@ hide_nav: true
     </div>
 </div>
 
+<!-- Store content is injected dynamically after password verification -->
+<!-- This prevents viewing store content in page source -->
 <div id="store-main" style="display: none;">
-<section id="Store" class="parallax">
-    <div class="container">
-        <div class="row-fluid">
-            <div class="store-content span12">
-                <div class="store-intro">
-                    <p>Purchase prints or book a portrait session.</p>
-                </div>
-
-                <!-- Success Message -->
-                <div id="success-message" class="success-banner" role="status" aria-live="polite" style="display: none;">
-                    <p>Thank you for your purchase! You'll receive a confirmation email shortly.</p>
-                </div>
-
-                <div class="store-sections">
-                    <!-- Prints Section -->
-                    <div class="store-section">
-                        <h3>Prints</h3>
-                        <p class="section-description">High-quality prints of my photography, professionally printed on archival paper.</p>
-
-                        <div class="product-grid" id="prints-grid">
-                            <div class="loading-placeholder">Loading prints...</div>
-                        </div>
-                    </div>
-
-                    <!-- Services Section -->
-                    <div class="store-section">
-                        <h3>Photography Services</h3>
-                        <p class="section-description">Book a portrait session for professional headshots, family photos, or special occasions.</p>
-
-                        <div class="services-grid" id="services-grid">
-                            <div class="loading-placeholder">Loading services...</div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="store-outro">
-                    <p><a href="/#Photography" class="back-link">&larr; Back</a></p>
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
+    <!-- Content loaded via password-verification.bundle.js -->
 </div>
 
 <script src="/static/js/dist/password-verification.bundle.js"></script>
@@ -309,19 +270,30 @@ hide_nav: true
         }
     }
 
-    // Initialize
-    document.addEventListener('DOMContentLoaded', function() {
-        checkAccess();
+    // Initialize store functionality after content is loaded
+    function initializeStore() {
         checkForSuccess();
         loadInventory();
 
         // Modal close handlers
-        document.querySelector('.checkout-modal-close').addEventListener('click', closeCheckoutModal);
-        document.querySelector('.checkout-modal-backdrop').addEventListener('click', closeCheckoutModal);
+        const closeBtn = document.querySelector('.checkout-modal-close');
+        const backdrop = document.querySelector('.checkout-modal-backdrop');
+
+        if (closeBtn) closeBtn.addEventListener('click', closeCheckoutModal);
+        if (backdrop) backdrop.addEventListener('click', closeCheckoutModal);
+
         document.addEventListener('keydown', function(e) {
             if (e.key === 'Escape') {
                 closeCheckoutModal();
             }
         });
+    }
+
+    // Listen for store content to be injected
+    document.addEventListener('storeContentLoaded', initializeStore);
+
+    // Check access on page load (will inject content if authorized)
+    document.addEventListener('DOMContentLoaded', function() {
+        checkAccess();
     });
 </script>


### PR DESCRIPTION
Implements content obfuscation to prevent casual viewing of store content in page source:

- Store HTML content is Base64 encoded at build time
- Content injected dynamically after password verification
- Prevents viewing store details via "View Source"

Technical implementation:
- encode-store-content.js: Encodes store section to Base64
- webpack DefinePlugin injects encoded content into bundle
- password-verification.ts decodes and injects on unlock
- store.html replaced with placeholder, listens for injection event